### PR TITLE
Add support to models stubbing

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "frint": "^0.3.1",
+    "frint": "^0.4.1",
     "lodash": "^4.13.1",
     "react": "^0.14.8"
   },
@@ -57,6 +57,7 @@
     "eslint-config-travix": "^1.1.0",
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-react": "^5.2.2",
+    "frint": "^0.4.1",
     "jsdom": "^9.4.2",
     "jsdom-global": "^2.0.0",
     "mocha": "^3.0.2",

--- a/src/createComponentStub.js
+++ b/src/createComponentStub.js
@@ -52,9 +52,11 @@ function stubContext(Component, context = {}) {
  */
 export default function createComponentStub(Component, opts) {
   const options = {
+    mapAppToProps: (app, fn) => fn(app),
     appOptions: {},
     dispatch: {},
     factories: {},
+    models: {},
     services: {},
     state: {},
     ...opts,
@@ -63,6 +65,25 @@ export default function createComponentStub(Component, opts) {
   const {
     app = {
       readableApps: [],
+      storeSubscriptions: [],
+      getFactory: (name) => {
+        const instance = options.factories[name];
+        if (!instance) {
+          throw new Error(
+            `Attempt to use factory '${name}' in test context, but no stubs have been provided.`
+          );
+        }
+        return instance;
+      },
+      getModel: (name) => {
+        const instance = options.models[name];
+        if (!instance) {
+          throw new Error(
+            `Attempt to use model '${name}' in test context, but no stubs have been provided.`
+          );
+        }
+        return instance;
+      },
       getService: (name) => {
         const instance = options.services[name];
         if (!instance) {
@@ -72,15 +93,6 @@ export default function createComponentStub(Component, opts) {
         }
         return instance;
       },
-      getFactory: (name) => {
-        const instance = options.factories[name];
-        if (!instance) {
-          throw new Error(
-            `Attempt to use factory '${name}' in test context, but no stubs have been provided.`
-          );
-        }
-        return instance;
-      },  
       getOption: (key) => options.appOptions[key],
     },
     store = {
@@ -90,6 +102,7 @@ export default function createComponentStub(Component, opts) {
     },
   } = options;
 
-  _.each(options.dispatch, (value, key) => Component.stub(key, value));
+  Component.stubMapAppToProps((appFn) => options.mapAppToProps(app, appFn));
+  _.each(options.dispatch, (value, key) => Component.stubMapDispatchToProps(key, value));
   return stubContext(Component, { app, store });
 }

--- a/test/createComponentStub.mockApp.js
+++ b/test/createComponentStub.mockApp.js
@@ -42,6 +42,8 @@ describe("createComponentStub :: app", function() {
     wrapper = mount(<ComponentStub />);
   });
 
+  afterEach(() => FakeComponent.resetStubs());
+
   after(() => {
     this.cleanup()
   });

--- a/test/createComponentStub.mockDispatchToAction.spec.js
+++ b/test/createComponentStub.mockDispatchToAction.spec.js
@@ -7,7 +7,7 @@ import { stub } from 'sinon';
 import { createComponent, mapToProps } from 'frint';
 import createComponentStub from '../src/createComponentStub';
 
-describe("createComponentStub", function() {
+describe("createComponentStub :: dispatch", function() {
   const TestComponent = createComponent({
     render() {
       return <button onClick={this.props.handleButtonClicked} />;
@@ -34,6 +34,8 @@ describe("createComponentStub", function() {
   });
 
   after(() => this.cleanup());
+
+  afterEach(() => FakeComponent.resetStubs());
 
   it("should be able to stub dispatch to action", () => {
     const wrapper = mount(<ComponentStub />);

--- a/test/createComponentStub.mockFactories.spec.js
+++ b/test/createComponentStub.mockFactories.spec.js
@@ -32,6 +32,7 @@ describe("createComponentStub :: factories", function() {
   });
 
   afterEach(() => {
+    FakeComponent.resetStubs();
     sandbox.restore();
     this.cleanup()
   });

--- a/test/createComponentStub.mockModel.spec.js
+++ b/test/createComponentStub.mockModel.spec.js
@@ -5,57 +5,58 @@ import sinon from 'sinon';
 import { createComponent, mapToProps } from 'frint';
 import createComponentStub from '../src/createComponentStub';
 
-describe('createComponentStub :: services', function() {
+describe("createComponentStub :: models", function() {
   const TestComponent = createComponent({
     render() {
       const { foo } = this.props;
-      return <button onClick={ () => foo.doSomething() } />;
+      return <span>{foo.getProperty()}</span>;
     },
   });
 
   const FakeComponent = mapToProps({
-    services: {
-      foo: 'bar',
-    }
+    app: (app) => {
+      const foo = app.getModel('foo');
+      return { foo };
+    },
   })(TestComponent);
 
-  const FooService = {
-    doSomething() { },
+  const FooModel = {
+    getProperty() { return 'fake property' },
   };
 
   let sandbox;
 
   beforeEach(() => {
-    this.cleanup = require('jsdom-global');
     sandbox = sinon.sandbox.create();
-    sandbox.stub(FooService, 'doSomething');
+    sandbox.stub(FooModel, 'getProperty');
+    this.cleanup = require('jsdom-global');
   });
 
   afterEach(() => {
     FakeComponent.resetStubs();
     sandbox.restore();
-    this.cleanup(); 
+    this.cleanup()
   });
 
-  it('should be able to stub services', () => {
+  it("should be able to stub models", () => {
     const ComponentStub = createComponentStub(FakeComponent, {
-      services: {
-        bar: FooService,
+      models: {
+        foo: FooModel,
       },
     });
     const wrapper = mount(<ComponentStub />);
-    wrapper.find('button').simulate('click');
-    expect(FooService.doSomething).to.have.been.calledOnce();
+    expect(FooModel.getProperty).to.have.been.calledOnce();
   });
 
   it('should error if stubs are not provided', () => {
     expect(() => {
       const ComponentStub = createComponentStub(FakeComponent, {
-        services: {
-          bar: null,
-        },
+        models: {
+          foo: null,
+        }
       });
-      mount(<ComponentStub />);
+      const wrapper = mount(<ComponentStub />);
+      console.log(wrapper.debug());
     }).to.throw(Error);
   })
 });

--- a/test/createComponentStub.mockModel.spec.js
+++ b/test/createComponentStub.mockModel.spec.js
@@ -14,10 +14,9 @@ describe("createComponentStub :: models", function() {
   });
 
   const FakeComponent = mapToProps({
-    app: (app) => {
-      const foo = app.getModel('foo');
-      return { foo };
-    },
+    models: {
+      foo: 'foo',
+    }
   })(TestComponent);
 
   const FooModel = {


### PR DESCRIPTION
With this PR you will be able to stub models, such as:

in `MyComponent.js`:
```js
const MyComponent = createComponent({
  render() {
    // expects model to be provided via props
    const { model } = this.props;
    // use model
    const something = model.getSomething();
  }
});

export default mapToProps({
  models: {
    model: 'model'
  }
})(MyComponent);
```

in `MyComponent.spec.js`:

```js
// creates a component stub that can be safely mounted using mock components
const ComponentStub = createComponentStub(MyComponent, {
  models: {
    model: modelStub
  },
};
```