### PR TITLE
Provide nice error message for installTestStubs

### DIFF
--- a/src/createComponentStub.js
+++ b/src/createComponentStub.js
@@ -2,6 +2,8 @@ import _ from 'lodash';
 import { PropTypes } from 'frint';
 import React from 'react';
 
+import { ensureTestStubsInstalled } from './installTestStubs';
+
 /**
  * Creates a component wrapper that implements `getChildContext` and `childContextTypes`.
  * @param  {Component} Component  a React component class
@@ -51,6 +53,7 @@ function stubContext(Component, context = {}) {
  * @return {Component}  a testable component that uses only stubs
  */
 export default function createComponentStub(Component, opts) {
+  ensureTestStubsInstalled('createComponentStub');
   const options = {
     mapAppToProps: (app, fn) => fn(app),
     appOptions: {},

--- a/src/installTestStubs.js
+++ b/src/installTestStubs.js
@@ -1,11 +1,24 @@
 import _ from 'lodash';
 import React from 'react';
 
+let testStubsAlreadyInstalled = false;
+
+export function ensureTestStubsInstalled(calledFunctionName) {
+  if (!testStubsAlreadyInstalled) {
+    throw new Error(`Attempt to call '${calledFunctionName}' before invoking 'installTestStubs' in test set up.`);
+  }
+}
+
 /**
  * Replaces frint exported functions with stubs.
  * This function needs to be called before all unit tests.
  */
 export default function installTestStubs() {
+  if (testStubsAlreadyInstalled) {
+    console.error('The test stubs are already installed, you do not have to call `installTestStubs` function again!');
+    return;
+  }
+
   const frint = require('frint');
 
   // keeps a copy of the original mapToProps implementation
@@ -56,4 +69,6 @@ export default function installTestStubs() {
       },
     });
   };
+
+  testStubsAlreadyInstalled = true;
 }

--- a/src/resetStubs.js
+++ b/src/resetStubs.js
@@ -1,0 +1,18 @@
+import _ from 'lodash';
+
+import { ensureTestStubsInstalled } from './installTestStubs';
+
+/**
+ * Reset component stubs
+ * @param {Component} Component   a component stubbed using `createComponentStub`
+ */
+export default function resetStubs(Component) {
+  ensureTestStubsInstalled('resetStubs');
+  if (!_.isFunction(Component)) {
+    throw new Error(`Invalid argument: 'Component'`);
+  }
+  if (!_.isFunction(Component.resetStubs)) {
+    throw new Error('Cannot reset stubs because component is not a stubbed component');
+  }
+  Component.resetStubs();
+}

--- a/test/createComponentStub.mockApp.js
+++ b/test/createComponentStub.mockApp.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import { createComponent, mapToProps } from 'frint';
 import createComponentStub from '../src/createComponentStub';
+import resetStubs from '../src/resetStubs';
 
 describe("createComponentStub :: app", function() {
   const TestComponent = createComponent({
@@ -42,7 +43,7 @@ describe("createComponentStub :: app", function() {
     wrapper = mount(<ComponentStub />);
   });
 
-  afterEach(() => FakeComponent.resetStubs());
+  afterEach(() => resetStubs(FakeComponent));
 
   after(() => {
     this.cleanup()

--- a/test/createComponentStub.mockDispatchToAction.spec.js
+++ b/test/createComponentStub.mockDispatchToAction.spec.js
@@ -6,6 +6,7 @@ import { stub } from 'sinon';
 
 import { createComponent, mapToProps } from 'frint';
 import createComponentStub from '../src/createComponentStub';
+import resetStubs from '../src/resetStubs';
 
 describe("createComponentStub :: dispatch", function() {
   const TestComponent = createComponent({
@@ -35,7 +36,7 @@ describe("createComponentStub :: dispatch", function() {
 
   after(() => this.cleanup());
 
-  afterEach(() => FakeComponent.resetStubs());
+  afterEach(() => resetStubs(FakeComponent));
 
   it("should be able to stub dispatch to action", () => {
     const wrapper = mount(<ComponentStub />);

--- a/test/createComponentStub.mockFactories.spec.js
+++ b/test/createComponentStub.mockFactories.spec.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 
 import { createComponent, mapToProps } from 'frint';
 import createComponentStub from '../src/createComponentStub';
+import resetStubs from '../src/resetStubs';
 
 describe("createComponentStub :: factories", function() {
   const TestComponent = createComponent({
@@ -32,7 +33,7 @@ describe("createComponentStub :: factories", function() {
   });
 
   afterEach(() => {
-    FakeComponent.resetStubs();
+    resetStubs(FakeComponent);
     sandbox.restore();
     this.cleanup()
   });

--- a/test/createComponentStub.mockModel.spec.js
+++ b/test/createComponentStub.mockModel.spec.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 
 import { createComponent, mapToProps } from 'frint';
 import createComponentStub from '../src/createComponentStub';
+import resetStubs from '../src/resetStubs';
 
 describe("createComponentStub :: models", function() {
   const TestComponent = createComponent({
@@ -32,7 +33,7 @@ describe("createComponentStub :: models", function() {
   });
 
   afterEach(() => {
-    FakeComponent.resetStubs();
+    resetStubs(FakeComponent);
     sandbox.restore();
     this.cleanup()
   });

--- a/test/createComponentStub.mockServices.spec.js
+++ b/test/createComponentStub.mockServices.spec.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 
 import { createComponent, mapToProps } from 'frint';
 import createComponentStub from '../src/createComponentStub';
+import resetStubs from '../src/resetStubs';
 
 describe('createComponentStub :: services', function() {
   const TestComponent = createComponent({
@@ -32,7 +33,7 @@ describe('createComponentStub :: services', function() {
   });
 
   afterEach(() => {
-    FakeComponent.resetStubs();
+    resetStubs(FakeComponent);
     sandbox.restore();
     this.cleanup(); 
   });

--- a/test/resetStubs.specs.js
+++ b/test/resetStubs.specs.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import { createComponent, mapToProps } from 'frint';
+import sinon from 'sinon';
+
+import createComponentStub from '../src/createComponentStub';
+import resetStubs from '../src/resetStubs';
+
+describe('resetStubs', function() {
+  const INVALID_COMPONENTS = [
+    { invalidComponent: null, description: 'null' },
+    { invalidComponent: undefined, description: 'undefined' },
+    { invalidComponent: {}, description: 'plain object' },
+    { invalidComponent: <div></div>, description: 'react element' },
+  ];
+
+  INVALID_COMPONENTS.forEach(({ invalidComponent, description }) => {
+    it(`should error if Component is not a valid frint component: '${description}'`, () => {
+      expect(() => {
+        resetStubs(invalidComponent);
+      }).to.throw(`Invalid argument: 'Component'`);
+    });
+  });
+
+  it('should error if Component is a pure react component', () => {
+    const ReactComponent = React.createClass({
+      render() {},
+    });
+    expect(() => {
+      resetStubs(ReactComponent);
+    }).to.throw('Cannot reset stubs because component is not a stubbed component');
+  });
+
+  it('should reset stubs of valid stubbed frint component', () => {
+    const FrintComponent = createComponent({
+      render() {},
+    });
+    const ConnectedComponent = mapToProps({})(FrintComponent);
+    sinon.stub(ConnectedComponent, 'resetStubs');
+    resetStubs(ConnectedComponent);
+    expect(ConnectedComponent.resetStubs).to.have.been.calledOnce();
+  });
+});


### PR DESCRIPTION
If you forget to call `installTestStubs` in your test setup, you will get an error message as soon as you call other frint-test functions such as `createComponentStub` and `resetStubs`.

If you call `installTestStubs` multiple times, you will be warned that the stubs are already in place, so you don't need to call it again.