### PR TITLE
Fix npm version on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Test utility functions for [frint](https://travix-international.github.io/frint).
 
-[![Build Status](https://travis-ci.org/Travix-International/frint-test.svg?branch=master)](https://travis-ci.org/Travix-International/frint-test) [![npm](https://img.shields.io/npm/v/frint-test.svg)](https://www.npmjs.com/package/frint)
+[![Build Status](https://travis-ci.org/Travix-International/frint-test.svg?branch=master)](https://travis-ci.org/Travix-International/frint-test) [![npm](https://img.shields.io/npm/v/frint-test.svg)](https://www.npmjs.com/package/frint-test)
 
 ## Installation
 


### PR DESCRIPTION
Link was showing `frint-test` version, but when you clicked on it you were getting redirected to frint package instead.