### PR TITLE
Use an actual app for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "eslint-config-travix": "^1.1.0",
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-react": "^5.2.2",
-    "frint": "^0.4.1",
     "gitbook-cli": "^2.3.0",
     "jsdom": "^9.4.2",
     "jsdom-global": "^2.0.0",

--- a/test/createComponentStub.mockDispatchToAction.spec.js
+++ b/test/createComponentStub.mockDispatchToAction.spec.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
-import { expect } from 'chai';
 import { mount } from 'enzyme';
-import { stub } from 'sinon';
+import { mock } from 'sinon';
 import { createComponent, mapToProps } from 'frint';
 
 import createComponentStub from '../src/createComponentStub';
@@ -25,7 +24,8 @@ describe('createComponentStub :: dispatch', function () {
 
   before(() => {
     this.cleanup = require('jsdom-global'); // eslint-disable-line global-require
-    handleButtonClicked = stub();
+    handleButtonClicked = mock().once().returns({ type: 'DOES_NOT_MATTER' });
+
     ComponentStub = createComponentStub(FakeComponent, {
       dispatch: {
         handleButtonClicked,
@@ -40,6 +40,6 @@ describe('createComponentStub :: dispatch', function () {
   it('should be able to stub dispatch to action', () => {
     const wrapper = mount(<ComponentStub />);
     wrapper.find('button').simulate('click');
-    expect(handleButtonClicked).to.have.been.calledOnce();
+    handleButtonClicked.verify();
   });
 });

--- a/test/createComponentStub.mockFactories.spec.js
+++ b/test/createComponentStub.mockFactories.spec.js
@@ -53,7 +53,7 @@ describe('createComponentStub :: factories', function () {
     expect(() => {
       const ComponentStub = createComponentStub(FakeComponent, {
         factories: {
-          bar: null,
+          bar_is_missing: null,
         },
       });
       mount(<ComponentStub />);

--- a/test/createComponentStub.mockModel.spec.js
+++ b/test/createComponentStub.mockModel.spec.js
@@ -52,7 +52,7 @@ describe('createComponentStub :: models', function () {
     expect(() => {
       const ComponentStub = createComponentStub(FakeComponent, {
         models: {
-          foo: null,
+          foo_is_missing: null,
         },
       });
       mount(<ComponentStub />);

--- a/test/createComponentStub.mockServices.spec.js
+++ b/test/createComponentStub.mockServices.spec.js
@@ -53,7 +53,7 @@ describe('createComponentStub :: services', function () {
     expect(() => {
       const ComponentStub = createComponentStub(FakeComponent, {
         services: {
-          bar: null,
+          bar_is_missing: null,
         },
       });
       mount(<ComponentStub />);


### PR DESCRIPTION
We have recently introduced some (non-official) `frint` API changes that break `frint-test` very badly, because we were depending on a fixed API (including non-documented method).  This has direct relation to the upcoming API changes proposed [here](https://github.com/Travix-International/frint/pull/40).

To avoid any potential changes in the future caused by changes in frint package, I've decided to fake an _actual_ app in test contexts, that is, we create an app using frint's `createApp` and _only_ override parts that are essential to testing, but always delegate the calls to the super class.  This allow us to add tracing/log errors that are useful in test context only without compromising the current frint-test API.

![screen shot 2016-11-07 at 16 46 42](https://cloud.githubusercontent.com/assets/1031418/20064671/c4f31670-a50b-11e6-91c4-ef001cc4b4f8.png)
