### PR TITLE
Add compatibility for frint next version

### DIFF
--- a/src/createComponentStub.js
+++ b/src/createComponentStub.js
@@ -35,6 +35,7 @@ export default function createComponentStub(Component, opts) {
 
   const createDefaultFakeApp = () => {
     const fakeAppOptions = {
+      isFrintCore: true,
       appId: 'fake_app',
       component: Component,
       enableLogger: false,
@@ -54,6 +55,20 @@ export default function createComponentStub(Component, opts) {
     const FakeApp = createApp(fakeAppOptions);
 
     class TestApp extends FakeApp {
+      // compatibility with frint next
+      get(name) {
+        if (name === 'rootApp' && this.options.isFrintCore) return this;
+
+        const result = super.get(name);
+        if (result == null) { // checks for either null or undefined
+          throw new Error(
+            `Attempt to use component '${name}' in test context, but no stubs have been provided.`
+          );
+        }
+
+        return result;
+      }
+
       getFactory(name) {
         if (!{}.hasOwnProperty.call(this.options.factories, name)) {
           throw new Error(


### PR DESCRIPTION
These changes are only to fix the internal component resolution in `frint next` version that fails in `frint-test`.

We won't be supporting for now a compatible way to test the new frint API, using `observe` for instance, and probably it won't be worth the effort to provide test helpers for that in the future.